### PR TITLE
Publish the TopoLens release in German and English

### DIFF
--- a/.github/pages-project-state.json
+++ b/.github/pages-project-state.json
@@ -31,9 +31,9 @@
     },
     "1077856806": {
       "repository": "TopoLens",
-      "deploymentId": 3165196817,
-      "sha": "68a07c23ee9907b83f9a91d0232e94526e336621",
-      "deployedAt": "2025-10-17T09:24:24Z",
+      "deploymentId": 5720718379,
+      "sha": "6fd5788e9f33f6e0efeb1a1a5e67002bab045ca9",
+      "deployedAt": "2026-08-03T04:10:36Z",
       "environmentUrl": "https://nyphon.de/TopoLens/"
     },
     "1106042250": {

--- a/.github/pages-projects.config.json
+++ b/.github/pages-projects.config.json
@@ -52,8 +52,8 @@
     "TopoLens": {
       "name": "TopoLens",
       "descriptions": {
-        "de": "Visualisiert aktuelle BGP-Ankündigungen und -Rückzüge aus dem RIPE-RIS-Live-Feed im Browser.",
-        "en": "Visualizes live BGP announcements and withdrawals from the RIPE RIS Live feed in the browser."
+        "de": "Mobiler Live-Observer für BGP-Routen und AS-Topologieänderungen mit Namenssuche, Pfad-Diffs und sichtbaren Feed-Lücken.",
+        "en": "Mobile live observer for BGP routes and AS-topology changes with network-name search, path diffs and explicit feed-gap handling."
       }
     }
   }

--- a/source-en/_data/projects.json
+++ b/source-en/_data/projects.json
@@ -1,5 +1,15 @@
 [
   {
+    "id": 1077856806,
+    "name": "TopoLens",
+    "url": "https://nyphon.de/TopoLens/",
+    "desc": "Mobile live observer for BGP routes and AS\\-topology changes with network\\-name search, path diffs and explicit feed\\-gap handling\\.",
+    "repository": "ralphschuler/TopoLens",
+    "repositoryUrl": "https://github.com/ralphschuler/TopoLens",
+    "deployedAt": "2026-08-03T04:10:36Z",
+    "deploymentSha": "6fd5788e9f33f6e0efeb1a1a5e67002bab045ca9"
+  },
+  {
     "id": 1321079205,
     "name": "Fundf",
     "url": "https://nyphon.de/fundf/",
@@ -28,16 +38,6 @@
     "repositoryUrl": "https://github.com/ralphschuler/terra-hub",
     "deployedAt": "2025-11-28T16:35:59Z",
     "deploymentSha": "0f3b98dfd48523a1815b3eb50aa9d7bc7bb4e061"
-  },
-  {
-    "id": 1077856806,
-    "name": "TopoLens",
-    "url": "https://nyphon.de/TopoLens/",
-    "desc": "Visualizes live BGP announcements and withdrawals from the RIPE RIS Live feed in the browser\\.",
-    "repository": "ralphschuler/TopoLens",
-    "repositoryUrl": "https://github.com/ralphschuler/TopoLens",
-    "deployedAt": "2025-10-17T09:24:24Z",
-    "deploymentSha": "68a07c23ee9907b83f9a91d0232e94526e336621"
   },
   {
     "id": 1074731179,

--- a/source-en/_posts/project-updates/1077856806-5720718379-en.md
+++ b/source-en/_posts/project-updates/1077856806-5720718379-en.md
@@ -1,0 +1,35 @@
+---
+title: "TopoLens: Track live BGP topology changes"
+date: "2026-08-03 06:10:36"
+updated: "2026-08-03 06:10:36"
+permalink: "project-updates/topolens/5720718379/"
+categories:
+  - "Project updates"
+tags:
+  - GitHub Pages
+  - "TopoLens"
+---
+
+[TopoLens](<https://nyphon.de/TopoLens/>) is now a mobile live observer for BGP routes and AS-topology changes. It is built for network engineers, developers and anyone who would rather inspect the actual AS path than watch an event counter climb.
+
+## What is included
+
+- **Find networks by name:** A search for “Facebook”, “Cloudflare” or an ASN queries RIPEstat and shows every matching ASN candidate with its registry description. TopoLens never silently chooses the first result for an ambiguous name.
+- **Watch origin announcements:** **Watch origin** turns the selected network into an explicit filter such as `32934$`. The fresh session then shows announcements whose observed AS path ends in that ASN.
+- **State instead of event counting:** Announcements and withdrawals are tracked as bounded session state per collector, peer and prefix. This produces real AS-to-AS edges and explainable path and origin changes.
+- **Map and Changes on small screens:** The mobile view switches deliberately between the topology and change feed. Search, filters, pause, reset and details remain thumb-friendly.
+- **Details for nerds:** The inspector exposes old and new AS paths, collector, peer, affected edges, sequence numbers, plus raw and normalized timestamps.
+- **Stable live operation:** Bounded buffers, workers, controlled reconnects, cancellable name lookups and explicit gap notices keep the interface useful during long or noisy streams.
+
+## Honest scope
+
+RIPE RIS Live does not provide an initial RIB snapshot to this view. TopoLens therefore shows the partial state observed since the session started and does not claim to represent a complete global routing table. Standalone withdrawals usually carry no AS path and may be absent from an origin-scoped session.
+
+## Release
+
+- Turn TopoLens into a mobile live topology tracker \(\#34\) ([`fb8854d`](<https://github.com/ralphschuler/TopoLens/commit/fb8854d130de227b9323d85659dbf7f64d92896c>))
+- Search live announcements by network name \(\#35\) ([`6fd5788`](<https://github.com/ralphschuler/TopoLens/commit/6fd5788e9f33f6e0efeb1a1a5e67002bab045ca9>))
+
+Published on 2026-08-03 from commit [`6fd5788e9f33`](<https://github.com/ralphschuler/TopoLens/commit/6fd5788e9f33f6e0efeb1a1a5e67002bab045ca9>).
+
+[Open project](<https://nyphon.de/TopoLens/>) · [View changes on GitHub](<https://github.com/ralphschuler/TopoLens/compare/68a07c23ee9907b83f9a91d0232e94526e336621...6fd5788e9f33f6e0efeb1a1a5e67002bab045ca9>)

--- a/source-en/projects/index.md
+++ b/source-en/projects/index.md
@@ -8,6 +8,14 @@ permalink: projects/index.html
 
 These are my automatically discovered GitHub Pages projects. The catalog is refreshed after successful deployments.
 
+## [TopoLens](<https://nyphon.de/TopoLens/>)
+
+Mobile live observer for BGP routes and AS\-topology changes with network\-name search, path diffs and explicit feed\-gap handling\.
+
+Last successful deployment: 2026-08-03
+
+[View project](<https://nyphon.de/TopoLens/>) · [Source code](<https://github.com/ralphschuler/TopoLens>)
+
 ## [Fundf](<https://nyphon.de/fundf/>)
 
 Open\-source project with a published GitHub Pages demo\.
@@ -31,14 +39,6 @@ Modular open\-source control and diagnostics platform for terrariums and vivariu
 Last successful deployment: 2025-11-28
 
 [View project](<https://nyphon.de/terra-hub/>) · [Source code](<https://github.com/ralphschuler/terra-hub>)
-
-## [TopoLens](<https://nyphon.de/TopoLens/>)
-
-Visualizes live BGP announcements and withdrawals from the RIPE RIS Live feed in the browser\.
-
-Last successful deployment: 2025-10-17
-
-[View project](<https://nyphon.de/TopoLens/>) · [Source code](<https://github.com/ralphschuler/TopoLens>)
 
 ## [OpenMediaVault Plugins](<https://nyphon.de/openmediavault-plugins/>)
 

--- a/source/_data/projects.json
+++ b/source/_data/projects.json
@@ -1,5 +1,15 @@
 [
   {
+    "id": 1077856806,
+    "name": "TopoLens",
+    "url": "https://nyphon.de/TopoLens/",
+    "desc": "Mobiler Live\\-Observer für BGP\\-Routen und AS\\-Topologieänderungen mit Namenssuche, Pfad\\-Diffs und sichtbaren Feed\\-Lücken\\.",
+    "repository": "ralphschuler/TopoLens",
+    "repositoryUrl": "https://github.com/ralphschuler/TopoLens",
+    "deployedAt": "2026-08-03T04:10:36Z",
+    "deploymentSha": "6fd5788e9f33f6e0efeb1a1a5e67002bab045ca9"
+  },
+  {
     "id": 1321079205,
     "name": "Fundf",
     "url": "https://nyphon.de/fundf/",
@@ -28,16 +38,6 @@
     "repositoryUrl": "https://github.com/ralphschuler/terra-hub",
     "deployedAt": "2025-11-28T16:35:59Z",
     "deploymentSha": "0f3b98dfd48523a1815b3eb50aa9d7bc7bb4e061"
-  },
-  {
-    "id": 1077856806,
-    "name": "TopoLens",
-    "url": "https://nyphon.de/TopoLens/",
-    "desc": "Visualisiert aktuelle BGP\\-Ankündigungen und \\-Rückzüge aus dem RIPE\\-RIS\\-Live\\-Feed im Browser\\.",
-    "repository": "ralphschuler/TopoLens",
-    "repositoryUrl": "https://github.com/ralphschuler/TopoLens",
-    "deployedAt": "2025-10-17T09:24:24Z",
-    "deploymentSha": "68a07c23ee9907b83f9a91d0232e94526e336621"
   },
   {
     "id": 1074731179,

--- a/source/_posts/project-updates/1077856806-5720718379-de.md
+++ b/source/_posts/project-updates/1077856806-5720718379-de.md
@@ -1,0 +1,35 @@
+---
+title: "TopoLens: BGP-Topologieänderungen live verfolgen"
+date: "2026-08-03 06:10:36"
+updated: "2026-08-03 06:10:36"
+permalink: "project-updates/topolens/5720718379/"
+categories:
+  - "Projektupdates"
+tags:
+  - GitHub Pages
+  - "TopoLens"
+---
+
+[TopoLens](<https://nyphon.de/TopoLens/>) ist jetzt ein mobiler Live-Observer für BGP-Routen und AS-Topologieänderungen. Das Tool richtet sich an Netzwerkmenschen, Entwickler und alle, die lieber den tatsächlichen AS-Pfad sehen als nur einen steigenden Event-Zähler.
+
+## Was jetzt drinsteckt
+
+- **Netze nach Namen finden:** Eine Suche nach „Facebook“, „Cloudflare“ oder einem ASN fragt RIPEstat ab und zeigt alle passenden ASN-Kandidaten mit Registry-Beschreibung. TopoLens wählt bei mehrdeutigen Namen nie automatisch den ersten Treffer.
+- **Origin-Announcements beobachten:** Mit **Watch origin** wird aus dem gewählten Netz ein expliziter Filter wie `32934$`. Die neue Session zeigt damit Announcements, deren beobachteter AS-Pfad in diesem ASN endet.
+- **Zustand statt Event-Zählung:** Ankündigungen und Rückzüge werden pro Collector, Peer und Präfix als begrenzter Session-Zustand verfolgt. Daraus entstehen reale AS-zu-AS-Kanten und nachvollziehbare Änderungen an Pfad und Ursprung.
+- **Map und Changes auf kleinen Screens:** Die mobile Ansicht wechselt gezielt zwischen Topologie und Änderungsfeed. Suche, Filter, Pause, Reset und Detailansicht bleiben mit dem Daumen erreichbar.
+- **Details für Nerds:** Der Inspector zeigt alten und neuen AS-Pfad, Collector, Peer, betroffene Kanten, Sequenz sowie rohe und normalisierte Zeitstempel.
+- **Stabiler Live-Betrieb:** Begrenzte Puffer, Worker, kontrollierte Reconnects, abbrechbare Namensabfragen und sichtbare Datenlücken halten die Oberfläche auch bei langen oder unruhigen Streams benutzbar.
+
+## Bewusst ehrlich
+
+RIPE RIS Live liefert in dieser Ansicht keinen initialen RIB-Snapshot. TopoLens zeigt deshalb die seit Sitzungsbeginn beobachtete Teilmenge und behauptet nicht, eine vollständige globale Routing-Tabelle abzubilden. Eigenständige Withdrawals tragen meist keinen AS-Pfad und können in einer auf den Origin begrenzten Session fehlen.
+
+## Release
+
+- Turn TopoLens into a mobile live topology tracker \(\#34\) ([`fb8854d`](<https://github.com/ralphschuler/TopoLens/commit/fb8854d130de227b9323d85659dbf7f64d92896c>))
+- Search live announcements by network name \(\#35\) ([`6fd5788`](<https://github.com/ralphschuler/TopoLens/commit/6fd5788e9f33f6e0efeb1a1a5e67002bab045ca9>))
+
+Veröffentlicht am 2026-08-03 mit Commit [`6fd5788e9f33`](<https://github.com/ralphschuler/TopoLens/commit/6fd5788e9f33f6e0efeb1a1a5e67002bab045ca9>).
+
+[Projekt öffnen](<https://nyphon.de/TopoLens/>) · [Änderungen auf GitHub](<https://github.com/ralphschuler/TopoLens/compare/68a07c23ee9907b83f9a91d0232e94526e336621...6fd5788e9f33f6e0efeb1a1a5e67002bab045ca9>)

--- a/source/projects/index.md
+++ b/source/projects/index.md
@@ -8,6 +8,14 @@ permalink: projects/index.html
 
 Hier findest du meine automatisch erkannten GitHub-Pages-Projekte. Die Liste wird nach erfolgreichen Veröffentlichungen aktualisiert.
 
+## [TopoLens](<https://nyphon.de/TopoLens/>)
+
+Mobiler Live\-Observer für BGP\-Routen und AS\-Topologieänderungen mit Namenssuche, Pfad\-Diffs und sichtbaren Feed\-Lücken\.
+
+Letzte erfolgreiche Veröffentlichung: 2026-08-03
+
+[Projekt ansehen](<https://nyphon.de/TopoLens/>) · [Quellcode](<https://github.com/ralphschuler/TopoLens>)
+
 ## [Fundf](<https://nyphon.de/fundf/>)
 
 Open\-Source\-Projekt mit einer veröffentlichten GitHub\-Pages\-Demo\.
@@ -31,14 +39,6 @@ Modulare Open\-Source\-Steuerung und Diagnoseplattform für Terrarien und Vivari
 Letzte erfolgreiche Veröffentlichung: 2025-11-28
 
 [Projekt ansehen](<https://nyphon.de/terra-hub/>) · [Quellcode](<https://github.com/ralphschuler/terra-hub>)
-
-## [TopoLens](<https://nyphon.de/TopoLens/>)
-
-Visualisiert aktuelle BGP\-Ankündigungen und \-Rückzüge aus dem RIPE\-RIS\-Live\-Feed im Browser\.
-
-Letzte erfolgreiche Veröffentlichung: 2025-10-17
-
-[Projekt ansehen](<https://nyphon.de/TopoLens/>) · [Quellcode](<https://github.com/ralphschuler/TopoLens>)
 
 ## [OpenMediaVault Plugins](<https://nyphon.de/openmediavault-plugins/>)
 


### PR DESCRIPTION
## Summary

- publish the verified TopoLens deployment `5720718379` as paired German and English release posts
- update the bilingual project catalog and deployment state
- explain network-name search, mobile topology tracking, stable streaming, and honest session semantics

## Validation

- `npm test` — 11/11 tests
- German and English Hexo builds
- generated home, article, and project routes
- canonical and hreflang links
- obsolete welcome/Hexo/Snipcart content remains absent
- remote Git tree exactly matches the locally verified tree